### PR TITLE
Fixes to matching observation times to program number and PI

### DIFF
--- a/src/pyspextool/batch/batch.py
+++ b/src/pyspextool/batch/batch.py
@@ -486,7 +486,7 @@ def processFolder(folder,verbose=False):
 # program and PI info (based on code by Evan Watson)
 # NOTE: in this realization we're assuming its the same program and PI for the entire folder
 # this overrules what is header
-	obs_sch = pd.read_csv(OBSERVER_SCHEDULE_FILE, usecols=['MJD START','MJD END','PROGRAM','PI'], index_col='MJD START')
+	obs_sch = pd.read_csv(OBSERVER_SCHEDULE_FILE, usecols=['MJD START','MJD END','PROGRAM','PI'])
 	mjd = dp['MJD'].iloc[1]
 	obs_sch = obs_sch[obs_sch['MJD START']<mjd]
 	obs_sch = obs_sch[obs_sch['MJD END']>mjd]

--- a/src/pyspextool/batch/batch.py
+++ b/src/pyspextool/batch/batch.py
@@ -189,7 +189,7 @@ IRSA_PREFIX = 'sbd.'
 REDUCTION_FOLDERS = ['data','cals','proc','qa']
 
 # observing schedule
-OBSERVER_SCHEDULE_FILE = os.path.join(DIR,'observer_schedule (1).csv')
+OBSERVER_SCHEDULE_FILE = os.path.join(DIR,'observer_schedule.csv')
 
 ##################################
 ####### BASIC TEST OF CODE #######

--- a/src/pyspextool/batch/batch.py
+++ b/src/pyspextool/batch/batch.py
@@ -189,7 +189,7 @@ IRSA_PREFIX = 'sbd.'
 REDUCTION_FOLDERS = ['data','cals','proc','qa']
 
 # observing schedule
-OBSERVER_SCHEDULE_FILE = os.path.join(DIR,'observer_schedule_compact.csv')
+OBSERVER_SCHEDULE_FILE = os.path.join(DIR,'observer_schedule (1).csv')
 
 ##################################
 ####### BASIC TEST OF CODE #######
@@ -486,8 +486,8 @@ def processFolder(folder,verbose=False):
 # program and PI info (based on code by Evan Watson)
 # NOTE: in this realization we're assuming its the same program and PI for the entire folder
 # this overrules what is header
-	obs_sch = pd.read_csv(OBSERVER_SCHEDULE_FILE)
-	mjd = dp['MJD'].iloc[int(len(dp)/2)]
+	obs_sch = pd.read_csv(OBSERVER_SCHEDULE_FILE, usecols=['MJD START','MJD END','PROGRAM','PI'], index_col='MJD START')
+	mjd = dp['MJD'].iloc[1]
 	obs_sch = obs_sch[obs_sch['MJD START']<mjd]
 	obs_sch = obs_sch[obs_sch['MJD END']>mjd]
 	if len(obs_sch)>0:


### PR DESCRIPTION
Changed to correct observer schedule file

Also changed the way we pick out one MJD time, still assuming same PI for entire log file. I noticed that sometimes the PI would stay way past their scheduled time, when this happens, the MJD value half-way through the list could actually be past the scheduled time as well (if they stayed long-enough), this means picking a value earlier in the list is better. 

This could potentially lead to an issue where the observer starts early, and therefore the code would think its the previous observer in the schedule. I am not sure if this will happen though. 

The usecols in the read_csv is just for speed, while the semester column is useful for manually checking observers, we dont need to read it in, which can save time, especially since it is such a large dataframe